### PR TITLE
rename executable com.vysp3r.ProtonPlus to protonplus

### DIFF
--- a/com.vysp3r.ProtonPlus.yml
+++ b/com.vysp3r.ProtonPlus.yml
@@ -4,7 +4,7 @@ runtime-version: '48'
 sdk: org.gnome.Sdk
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.vala
-command: com.vysp3r.ProtonPlus
+command: protonplus
 finish-args:
   - --device=dri
   - --share=ipc


### PR DESCRIPTION
Merge after the PR below:

- depends on the PR https://github.com/Vysp3r/ProtonPlus/pull/338
- rename the executable to reflect the name of the project/package
- ensure compliance with Fedora packaging guidelines

Reference:
https://docs.fedoraproject.org/en-US/packaging-guidelines/Naming/#_case_sensitivity